### PR TITLE
Update to .NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Pack
       run: |
         arrTag=(${GITHUB_REF//\// })

--- a/Metalsharp.Tests/GlobalSuppressions.cs
+++ b/Metalsharp.Tests/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "Always off because annoying", Scope = "namespace", Target = "~N:Metalsharp.Tests")]

--- a/Metalsharp.Tests/Metalsharp.Tests.csproj
+++ b/Metalsharp.Tests/Metalsharp.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Metalsharp.Tests/Metalsharp.Tests.csproj
+++ b/Metalsharp.Tests/Metalsharp.Tests.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <Content Include="Scenario\**\*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/Metalsharp.Tests/Metalsharp.Tests.csproj
+++ b/Metalsharp.Tests/Metalsharp.Tests.csproj
@@ -1,98 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-
+    <TargetFramework>net8</TargetFramework>
     <IsPackable>false</IsPackable>
-
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Scenario\Directory1\file1.md" />
-    <None Remove="Scenario\Directory1\file2.md" />
-    <None Remove="Scenario\Directory1\file3.md" />
-    <None Remove="Scenario\Directory1\file4.md" />
-    <None Remove="Scenario\Directory1\file5.md" />
-    <None Remove="Scenario\Directory2\file10.md" />
-    <None Remove="Scenario\Directory2\file6.md" />
-    <None Remove="Scenario\Directory2\file7.md" />
-    <None Remove="Scenario\Directory2\file8.md" />
-    <None Remove="Scenario\Directory2\file9.md" />
-    <None Remove="Scenario\Directory2\SubDirectory1\file11.md" />
-    <None Remove="Scenario\Directory2\SubDirectory1\file12.md" />
-    <None Remove="Scenario\Directory2\SubDirectory1\file13.md" />
-    <None Remove="Scenario\Directory2\SubDirectory1\file14.md" />
-    <None Remove="Scenario\Directory2\SubDirectory1\file15.md" />
-    <None Remove="Scenario\Plugins\FileJsonFrontmatter.md" />
-    <None Remove="Scenario\Plugins\FileMarkdown.md" />
-    <None Remove="Scenario\Plugins\FileYamlFrontmatter.md" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Scenario\Plugins\FileYamlFrontmatter.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Scenario\Plugins\FileJsonFrontmatter.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Scenario\Plugins\FileMarkdown.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Scenario\Directory1\file1.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory1\file2.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory1\file3.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory1\file4.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory1\file5.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\file10.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\file6.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\file7.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\file8.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\file9.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\SubDirectory1\file11.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\SubDirectory1\file12.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\SubDirectory1\file13.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\SubDirectory1\file14.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scenario\Directory2\SubDirectory1\file15.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <Content Include="Scenario\**\*">
   </ItemGroup>
 
   <ItemGroup>

--- a/Metalsharp.Tests/MetalsharpFileCollectionTests.cs
+++ b/Metalsharp.Tests/MetalsharpFileCollectionTests.cs
@@ -1,34 +1,36 @@
 ﻿using System.Linq;
 using Xunit;
 
-namespace Metalsharp.Tests
+namespace Metalsharp.Tests;
+
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
+public class MetalsharpFileCollectionTests
 {
-    public class MetalsharpFileCollectionTests
+    [Theory]
+    [InlineData(new[] { "Dir1\\F1.a", "Dir1\\F2.a", "Dir2\\F3.a" }, "Dir1", new[] { "F1", "F2" })]
+    [InlineData(new[] { "Dir1\\Dir2\\F1.a", "Dir1\\Dir3\\F2.a", "Dir4\\F3.a" }, "Dir1", new[] { "F1", "F2" })]
+    public void DescendantsOfReturnsCorrectFiles(string[] paths, string ancestorDirectory, string[] expectedFileNames)
     {
-        [Theory]
-        [InlineData(new[] { "Dir1\\F1.a", "Dir1\\F2.a", "Dir2\\F3.a" }, "Dir1", new[] { "F1", "F2" })]
-        [InlineData(new[] { "Dir1\\Dir2\\F1.a", "Dir1\\Dir3\\F2.a", "Dir4\\F3.a" }, "Dir1", new[] { "F1", "F2" })]
-        public void DescendantsOfReturnsCorrectFiles(string[] paths, string ancestorDirectory, string[] expectedFileNames)
-        {
-            var collection = new MetalsharpFileCollection(paths.Select(p => new MetalsharpFile("text", p)));
+        var collection = new MetalsharpFileCollection(paths.Select(p => new MetalsharpFile("text", p)));
 
-            foreach (var name in collection.DescendantsOf(ancestorDirectory).Select(i => i.Name))
-            {
-                Assert.Contains(name, expectedFileNames);
-            }
+        foreach (var name in collection.DescendantsOf(ancestorDirectory).Select(i => i.Name))
+        {
+            Assert.Contains(name, expectedFileNames);
         }
+    }
 
-        [Theory]
-        [InlineData(new[] { "Dir1\\F1.a", "Dir1\\F2.a", "Dir2\\F3.a" }, "Dir1", new[] { "F1", "F2" })]
-        [InlineData(new[] { "Dir1\\Dir2\\F1.a", "Dir3\\Dir2\\F2.a", "Dir4\\F3.a" }, "Dir2", new[] { "F1", "F2" })]
-        public void ChildrenOfReturnsCorrectFiles(string[] paths, string parentDirectory, string[] expectedFileNames)
+    [Theory]
+    [InlineData(new[] { "Dir1\\F1.a", "Dir1\\F2.a", "Dir2\\F3.a" }, "Dir1", new[] { "F1", "F2" })]
+    [InlineData(new[] { "Dir1\\Dir2\\F1.a", "Dir3\\Dir2\\F2.a", "Dir4\\F3.a" }, "Dir2", new[] { "F1", "F2" })]
+    public void ChildrenOfReturnsCorrectFiles(string[] paths, string parentDirectory, string[] expectedFileNames)
+    {
+        var collection = new MetalsharpFileCollection(paths.Select(p => new MetalsharpFile("text", p)));
+
+        foreach (var name in collection.ChildrenOf(parentDirectory).Select(i => i.Name))
         {
-            var collection = new MetalsharpFileCollection(paths.Select(p => new MetalsharpFile("text", p)));
-
-            foreach (var name in collection.ChildrenOf(parentDirectory).Select(i => i.Name))
-            {
-                Assert.Contains(name, expectedFileNames);
-            }
+            Assert.Contains(name, expectedFileNames);
         }
     }
 }
+#pragma warning restore CA1861
+

--- a/Metalsharp.Tests/MetalsharpFileTests.cs
+++ b/Metalsharp.Tests/MetalsharpFileTests.cs
@@ -13,7 +13,7 @@ namespace Metalsharp.Tests
         [InlineData("Directory1\\Directory2\\file.html")]
         public void DirectoryReturnsCorrectResult(string path)
         {
-            var file = new MetalsharpFile("text", path, new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", path, []);
 
             Assert.True(file.Directory == Path.GetDirectoryName(path));
         }
@@ -24,7 +24,7 @@ namespace Metalsharp.Tests
         [InlineData("Directory1\\Directory2\\file.html", "Dir")]
         public void DirectoryAssignsCorrectValue(string path, string directoryToAssign)
         {
-            var file = new MetalsharpFile("text", path, new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", path, []);
             file.Directory = directoryToAssign;
 
             Assert.True(file.FilePath == Path.Combine(directoryToAssign, Path.GetFileName(file.FilePath)));
@@ -36,7 +36,7 @@ namespace Metalsharp.Tests
         [InlineData("Directory1\\Directory2\\file.html")]
         public void ExtensionReturnsCorrectResult(string path)
         {
-            var file = new MetalsharpFile("text", path, new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", path, []);
 
             Assert.True(file.Extension == Path.GetExtension(path));
         }
@@ -47,7 +47,7 @@ namespace Metalsharp.Tests
         [InlineData("Directory1\\Directory2\\file.html", ".h")]
         public void ExtensionAssignsCorrectValue(string path, string extensionToAssign)
         {
-            var file = new MetalsharpFile("text", path, new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", path, []);
             file.Extension = extensionToAssign;
 
             Assert.True(file.FilePath == Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path) + extensionToAssign));
@@ -56,7 +56,7 @@ namespace Metalsharp.Tests
         [Fact]
         public void FilePathWorks()
         {
-            var file = new MetalsharpFile("text", "path", new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", "path", []);
             Assert.True(file.FilePath == "path");
 
             file.FilePath = "newpath";
@@ -80,7 +80,7 @@ namespace Metalsharp.Tests
         [InlineData("Directory1\\Directory2\\file.html")]
         public void NameReturnsCorrectResult(string path)
         {
-            var file = new MetalsharpFile("text", path, new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", path, []);
 
             Assert.True(file.Name == Path.GetFileNameWithoutExtension(path));
         }
@@ -91,7 +91,7 @@ namespace Metalsharp.Tests
         [InlineData("Directory1\\Directory2\\file.html", "newfile3")]
         public void NameAssignsCorrectValue(string path, string nameToAssign)
         {
-            var file = new MetalsharpFile("text", path, new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", path, []);
             file.Name = nameToAssign;
 
             Assert.True(file.FilePath == Path.Combine(Path.GetDirectoryName(path), nameToAssign + Path.GetExtension(path)));
@@ -100,10 +100,10 @@ namespace Metalsharp.Tests
         [Fact]
         public void TextWorks()
         {
-            var file = new MetalsharpFile("text", "path", new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", "path", []);
             Assert.True(file.Text == "text");
 
-            file.Contents = Encoding.Default.GetBytes("newtext");
+            file.Bytes = Encoding.Default.GetBytes("newtext");
             Assert.True(file.Text == "newtext");
         }
 
@@ -116,7 +116,7 @@ namespace Metalsharp.Tests
         [InlineData("Directory1\\Directory2\\file.txt", "Directory1\\Directory3", false)]
         public void IsDescendantOfReturnsCorrectResult(string path, string ancestorDirectory, bool expectedResult)
         {
-            var file = new MetalsharpFile("text", path, new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", path, []);
 
             Assert.True(file.IsDescendantOf(ancestorDirectory) == expectedResult);
         }
@@ -131,7 +131,7 @@ namespace Metalsharp.Tests
         [InlineData("Directory1\\Directory2\\file.txt", "Directory1\\Directory3", false)]
         public void IsChildOfReturnsCorrectResult(string path, string parentDirectory, bool expectedResult)
         {
-            var file = new MetalsharpFile("text", path, new Dictionary<string, object>());
+            var file = new MetalsharpFile("text", path, []);
 
             Assert.True(file.IsChildOf(parentDirectory) == expectedResult);
         }

--- a/Metalsharp.Tests/MetalsharpProjectTests.cs
+++ b/Metalsharp.Tests/MetalsharpProjectTests.cs
@@ -3,460 +3,459 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace Metalsharp.Tests
+namespace Metalsharp.Tests;
+
+public class MetalsharpProjectTests
 {
-    public class MetalsharpProjectTests
+    #region Add Files
+
+    [Theory]
+    [InlineData("Scenario\\Directory1", 5)]
+    [InlineData("Scenario\\Directory2", 10)]
+    public void AddInputSinglePathAddsCorrectNumberOfFiles(string path, int expectedFileCount)
     {
-        #region Add Files
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddInput(path);
+        Assert.True(project.InputFiles.Count == expectedFileCount);
+    }
 
-        [Theory]
-        [InlineData("Scenario\\Directory1", 5)]
-        [InlineData("Scenario\\Directory2", 10)]
-        public void AddInputSinglePathAddsCorrectNumberOfFiles(string path, int expectedFileCount)
+    [Theory]
+    [InlineData("Scenario\\Directory1", "Scenario\\Directory1")]
+    [InlineData("Scenario\\Directory1", "Dir")]
+    [InlineData("Scenario\\Directory1\\file1.md", "Scenario\\Directory1")]
+    [InlineData("Scenario\\Directory1\\file1.md", "Dir")]
+    [InlineData("Scenario\\Directory2", "Dir")]
+    public void AddInputAddsFilesToCorrectDirectory(string diskPath, string virtualPath)
+    {
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddInput(diskPath, virtualPath);
+
+        foreach (var file in project.InputFiles)
         {
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddInput(path);
-            Assert.True(project.InputFiles.Count == expectedFileCount);
+            var newPath = (Directory.Exists(diskPath) ? diskPath : Path.GetDirectoryName(diskPath)) +
+                string.Concat(file.FilePath.Skip(virtualPath.Length));
+
+            Assert.True(File.Exists(newPath));
+        }
+    }
+
+    [Fact]
+    public void AddInputThrowsGivenNonexistantPath()
+    {
+        var nonexistentPath = "\\Does\\Not\\Exist";
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
+
+        Assert.Throws<ArgumentException>(() => project.AddInput(nonexistentPath));
+        Assert.Throws<ArgumentException>(() => project.AddInput(nonexistentPath, "Dir"));
+    }
+
+    [Fact]
+    public void AddInputAddsMetalsharpFile()
+    {
+        var file = new MetalsharpFile("fileText", "filePath");
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddInput(file);
+
+        Assert.Contains(file, project.InputFiles);
+    }
+
+    [Theory]
+    [InlineData("Scenario\\Directory1", 5)]
+    [InlineData("Scenario\\Directory2", 10)]
+    public void AddOutputSinglePathAddsCorrectNumberOfFiles(string path, int expectedFileCount)
+    {
+        var project = new MetalsharpProject().AddOutput(path);
+        Assert.True(project.OutputFiles.Count == expectedFileCount);
+    }
+
+    [Theory]
+    [InlineData("Scenario\\Directory1", "Scenario\\Directory1")]
+    [InlineData("Scenario\\Directory1", "Dir")]
+    [InlineData("Scenario\\Directory1\\file1.md", "Scenario\\Directory1")]
+    [InlineData("Scenario\\Directory1\\file1.md", "Dir")]
+    [InlineData("Scenario\\Directory2", "Dir")]
+    public void AddOutputAddsFilesToCorrectDirectory(string diskPath, string virtualPath)
+    {
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddOutput(diskPath, virtualPath);
+
+        foreach (var file in project.OutputFiles)
+        {
+            var newPath = (Directory.Exists(diskPath) ? diskPath : Path.GetDirectoryName(diskPath)) +
+                string.Concat(file.FilePath.Skip(virtualPath.Length));
+
+            Assert.True(File.Exists(newPath));
+        }
+    }
+
+    [Fact]
+    public void AddOutputThrowsGivenNonexistantPath()
+    {
+        var nonexistentPath = "\\Does\\Not\\Exist";
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
+
+        Assert.Throws<ArgumentException>(() => project.AddOutput(nonexistentPath));
+        Assert.Throws<ArgumentException>(() => project.AddOutput(nonexistentPath, "Dir"));
+    }
+
+    [Fact]
+    public void AddOutputAddsMetalsharpFile()
+    {
+        var file = new MetalsharpFile("fileText", "filePath");
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddOutput(file);
+
+        Assert.Contains(file, project.OutputFiles);
+    }
+
+    #endregion
+
+    #region Build
+
+    [Fact]
+    public void BuildWithDefaultOptionsWritesToCurrentDirectory()
+    {
+        if (File.Exists("OutputFile1.txt"))
+        {
+            File.Delete("OutputFile1.txt");
         }
 
-        [Theory]
-        [InlineData("Scenario\\Directory1", "Scenario\\Directory1")]
-        [InlineData("Scenario\\Directory1", "Dir")]
-        [InlineData("Scenario\\Directory1\\file1.md", "Scenario\\Directory1")]
-        [InlineData("Scenario\\Directory1\\file1.md", "Dir")]
-        [InlineData("Scenario\\Directory2", "Dir")]
-        public void AddInputAddsFilesToCorrectDirectory(string diskPath, string virtualPath)
-        {
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddInput(diskPath, virtualPath);
-
-            foreach (var file in project.InputFiles)
-            {
-                var newPath = (Directory.Exists(diskPath) ? diskPath : Path.GetDirectoryName(diskPath)) +
-                    string.Concat(file.FilePath.Skip(virtualPath.Length));
-
-                Assert.True(File.Exists(newPath));
-            }
-        }
-
-        [Fact]
-        public void AddInputThrowsGivenNonexistantPath()
-        {
-            var nonexistentPath = "\\Does\\Not\\Exist";
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
-
-            Assert.Throws<ArgumentException>(() => project.AddInput(nonexistentPath));
-            Assert.Throws<ArgumentException>(() => project.AddInput(nonexistentPath, "Dir"));
-        }
-
-        [Fact]
-        public void AddInputAddsMetalsharpFile()
-        {
-            var file = new MetalsharpFile("fileText", "filePath");
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddInput(file);
-
-            Assert.Contains(file, project.InputFiles);
-        }
-
-        [Theory]
-        [InlineData("Scenario\\Directory1", 5)]
-        [InlineData("Scenario\\Directory2", 10)]
-        public void AddOutputSinglePathAddsCorrectNumberOfFiles(string path, int expectedFileCount)
-        {
-            var project = new MetalsharpProject().AddOutput(path);
-            Assert.True(project.OutputFiles.Count == expectedFileCount);
-        }
-
-        [Theory]
-        [InlineData("Scenario\\Directory1", "Scenario\\Directory1")]
-        [InlineData("Scenario\\Directory1", "Dir")]
-        [InlineData("Scenario\\Directory1\\file1.md", "Scenario\\Directory1")]
-        [InlineData("Scenario\\Directory1\\file1.md", "Dir")]
-        [InlineData("Scenario\\Directory2", "Dir")]
-        public void AddOutputAddsFilesToCorrectDirectory(string diskPath, string virtualPath)
-        {
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddOutput(diskPath, virtualPath);
-
-            foreach (var file in project.OutputFiles)
-            {
-                var newPath = (Directory.Exists(diskPath) ? diskPath : Path.GetDirectoryName(diskPath)) +
-                    string.Concat(file.FilePath.Skip(virtualPath.Length));
-
-                Assert.True(File.Exists(newPath));
-            }
-        }
-
-        [Fact]
-        public void AddOutputThrowsGivenNonexistantPath()
-        {
-            var nonexistentPath = "\\Does\\Not\\Exist";
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
-
-            Assert.Throws<ArgumentException>(() => project.AddOutput(nonexistentPath));
-            Assert.Throws<ArgumentException>(() => project.AddOutput(nonexistentPath, "Dir"));
-        }
-
-        [Fact]
-        public void AddOutputAddsMetalsharpFile()
-        {
-            var file = new MetalsharpFile("fileText", "filePath");
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddOutput(file);
-
-            Assert.Contains(file, project.OutputFiles);
-        }
-
-        #endregion
-
-        #region Build
-
-        [Fact]
-        public void BuildWithDefaultOptionsWritesToCurrentDirectory()
-        {
-            if (File.Exists("OutputFile1.txt"))
-            {
-                File.Delete("OutputFile1.txt");
-            }
-
-            new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddOutput(new MetalsharpFile("text", "OutputFile1.txt"))
-                .Build();
-
-            Assert.True(File.Exists("OutputFile1.txt"));
-        }
-
-        [Fact]
-        public void BuildWithDefaultOptionsDoesNotOverwriteOutputDirectory()
-        {
-            if (!File.Exists("ShouldNotDelete.txt"))
-            {
-                File.Create("ShouldNotDelete.txt");
-            }
-
-            new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddOutput(new MetalsharpFile("text", "OutputFile1.txt"))
-                .Build();
-
-            Assert.True(File.Exists("ShouldNotDelete.txt"));
-        }
-
-        [Fact]
-        public void BuildWritesOutputFilesToOutputDirectory()
-        {
-            new MetalsharpProject(
-                clearOutputDirectory: true,
-                outputDirectory: "Output",
-                verbosity: LogLevel.None
-            )
-            .AddInput(new MetalsharpFile("text", "InputFile1.txt"))
-            .AddInput(new MetalsharpFile("text", "InputDir\\InputFile2.txt"))
+        new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
             .AddOutput(new MetalsharpFile("text", "OutputFile1.txt"))
-            .AddOutput(new MetalsharpFile("text", "OutputDir\\OutputFile2.txt"))
             .Build();
 
-            Assert.True(File.Exists("Output\\OutputFile1.txt"));
-            Assert.True(File.Exists("Output\\OutputDir\\OutputFile2.txt"));
-
-            Assert.False(File.Exists("Output\\InputFile1.txt"));
-            Assert.False(File.Exists("Output\\InputDir\\InputFile2.txt"));
-        }
-
-        [Fact]
-        public void BuildInvokesBeforeBuildEvent()
-        {
-            var wasInvoked = false;
-
-            if (File.Exists("OutputFile3.txt"))
-            {
-                File.Delete("OutputFile3.txt");
-            }
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddOutput(new MetalsharpFile("text", "OutputFile3.txt"));
-
-            project.BeforeBuild += (sender, e) =>
-            {
-                wasInvoked = true;
-                Assert.False(File.Exists("OutputFile3.txt"));
-            };
-
-            project.Build();
-
-            Assert.True(wasInvoked);
-        }
-
-        [Fact]
-        public void BuildInvokesAfterBuildEvent()
-        {
-            var wasInvoked = false;
-
-            if (File.Exists("OutputFile4.txt"))
-            {
-                File.Delete("OutputFile4.txt");
-            }
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddOutput(new MetalsharpFile("text", "OutputFile4.txt"));
-
-            project.AfterBuild += (sender, e) =>
-            {
-                wasInvoked = true;
-                // File may or may not exist here - cannot test this?
-            };
-
-            project.Build();
-
-            Assert.True(wasInvoked);
-        }
-
-        #endregion
-
-        #region Metadata
-
-        [Fact]
-        public void MetadataSinglePairAddsAndOverwrites()
-        {
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
-
-            project.Meta("key", "value1");
-            Assert.True(project.Metadata.ContainsKey("key"));
-            Assert.True(project.Metadata["key"].ToString() == "value1");
-
-            project.Meta("key", "value2");
-            Assert.True(project.Metadata["key"].ToString() == "value2");
-        }
-
-        [Fact]
-        public void MetadataMultiplePairsAddAndOverwrite()
-        {
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
-
-            project.Meta(("key1", "value1"), ("key2", "value1"), ("key3", "value1"));
-            Assert.True(project.Metadata.ContainsKey("key1"));
-            Assert.True(project.Metadata.ContainsKey("key2"));
-            Assert.True(project.Metadata.ContainsKey("key3"));
-            Assert.True(project.Metadata["key1"].ToString() == "value1");
-            Assert.True(project.Metadata["key2"].ToString() == "value1");
-            Assert.True(project.Metadata["key3"].ToString() == "value1");
-
-            project.Meta(("key1", "value2"), ("key2", "value2"), ("key3", "value2"));
-            Assert.True(project.Metadata["key1"].ToString() == "value2");
-            Assert.True(project.Metadata["key2"].ToString() == "value2");
-            Assert.True(project.Metadata["key3"].ToString() == "value2");
-        }
-
-        #endregion
-
-        #region Move Files
-
-        [Fact]
-        public void MoveFilesByPathEquivalentToInputAndOutput()
-        {
-            var file = new MetalsharpFile("text", "dir1\\File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddInput(file)
-                .AddOutput(file)
-                .MoveFiles("dir1", "dir2");
-
-            Assert.True(project.InputFiles[0].Directory == "dir2");
-            Assert.True(project.OutputFiles[0].Directory == "dir2");
-        }
-
-        [Fact]
-        public void MoveFilesByPredicateEquivalentToInputAndOutput()
-        {
-            var file = new MetalsharpFile("text", "dir1\\File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddInput(file)
-                .AddOutput(file)
-                .MoveFiles(f => f.Text == "text", "dir2");
-
-            Assert.True(project.InputFiles[0].Directory == "dir2");
-            Assert.True(project.OutputFiles[0].Directory == "dir2");
-        }
-
-        [Fact]
-        public void MoveInputByPathMovesFilesCorrectly()
-        {
-            var file = new MetalsharpFile("text", "dir1\\File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddInput(file)
-                .MoveInput("dir1", "dir2");
-
-            Assert.True(project.InputFiles[0].Directory == "dir2");
-        }
-
-        [Fact]
-        public void MoveInputByPredicateSelectsFilesCorrectly()
-        {
-            var file = new MetalsharpFile("text", "dir1\\File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddInput(file)
-                .MoveInput(f => f.Text == "text", "dir2");
-
-            Assert.True(project.InputFiles[0].Directory == "dir2");
-        }
-
-        [Fact]
-        public void MoveOutputByPathMovesFilesCorrectly()
-        {
-            var file = new MetalsharpFile("text", "dir1\\File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddOutput(file)
-                .MoveOutput("dir1", "dir2");
-
-            Assert.True(project.OutputFiles[0].Directory == "dir2");
-        }
-
-        [Fact]
-        public void MoveOutputByPredicateSelectsFilesCorrectly()
-        {
-            var file = new MetalsharpFile("text", "dir1\\File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddOutput(file)
-                .MoveOutput(f => f.Text == "text", "dir2");
-
-            Assert.True(project.OutputFiles[0].Directory == "dir2");
-        }
-
-        #endregion
-
-        #region Remove Files
-
-        [Fact]
-        public void RemoveFilesByPathEquivalentToInputAndOutput()
-        {
-            var file = new MetalsharpFile("text", "File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddInput(file)
-                .AddOutput(file)
-                .RemoveFiles(file.FilePath);
-
-            Assert.DoesNotContain(file, project.InputFiles);
-            Assert.DoesNotContain(file, project.OutputFiles);
-        }
-
-        [Fact]
-        public void RemoveFilesByPredicateEquivalentToInputAndOutput()
-        {
-            var file = new MetalsharpFile("text", "File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddInput(file)
-                .AddOutput(file)
-                .RemoveFiles(f => f.Text == "text");
-
-            Assert.DoesNotContain(file, project.InputFiles);
-            Assert.DoesNotContain(file, project.OutputFiles);
-        }
-
-        [Fact]
-        public void RemoveInputByPathRemovesFilesCorrectly()
-        {
-            var file = new MetalsharpFile("text", "File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddInput(file)
-                .RemoveInput(file.FilePath);
-
-            Assert.DoesNotContain(file, project.InputFiles);
-        }
-
-        [Fact]
-        public void RemoveInputByPredicateSelectsFilesCorrectly()
-        {
-            var file = new MetalsharpFile("text", "File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddInput(file)
-                .RemoveInput(f => f.Text == "text");
-
-            Assert.DoesNotContain(file, project.InputFiles);
-        }
-
-        [Fact]
-        public void RemoveOutputByPathRemovesFilesCorrectly()
-        {
-            var file = new MetalsharpFile("text", "File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddOutput(file)
-                .RemoveOutput(file.FilePath);
-
-            Assert.DoesNotContain(file, project.OutputFiles);
-        }
-
-        [Fact]
-        public void RemoveOutputByPredicateSelectsFilesCorrectly()
-        {
-            var file = new MetalsharpFile("text", "File.txt");
-
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
-                .AddOutput(file)
-                .RemoveOutput(f => f.Text == "text");
-
-            Assert.DoesNotContain(file, project.OutputFiles);
-        }
-
-        #endregion
-
-        #region Use
-
-        [Fact]
-        public void UsePluginInstanceExecutesPlugin()
-        {
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).Use(new TestPlugin());
-
-            Assert.True((bool)project.Metadata["test"]);
-        }
-
-        [Fact]
-        public void UsePluginTypeExecutesPlugin()
-        {
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).Use<TestPlugin>();
-
-            Assert.True((bool)project.Metadata["test"]);
-        }
-
-        [Fact]
-        public void UseFuncExecutesFunc()
-        {
-            var wasExecuted = false;
-            new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).Use(proj => wasExecuted = true);
-
-            Assert.True(wasExecuted);
-        }
-
-        [Fact]
-        public void UseInvokesBeforeUseEevent()
-        {
-            var wasExecuted = false;
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
-
-            project.BeforeUse += (sender, e) =>
-            {
-                Assert.False(wasExecuted);
-            };
-
-            project.Use(proj => wasExecuted = true);
-        }
-
-        [Fact]
-        public void UseInvokesAfterUseEvent()
-        {
-            var wasExecuted = false;
-            var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
-
-            project.AfterUse += (sender, e) =>
-            {
-                Assert.True(wasExecuted);
-            };
-
-            project.Use(proj => wasExecuted = true);
-        }
-
-        #endregion
+        Assert.True(File.Exists("OutputFile1.txt"));
     }
+
+    [Fact]
+    public void BuildWithDefaultOptionsDoesNotOverwriteOutputDirectory()
+    {
+        if (!File.Exists("ShouldNotDelete.txt"))
+        {
+            File.Create("ShouldNotDelete.txt");
+        }
+
+        new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddOutput(new MetalsharpFile("text", "OutputFile1.txt"))
+            .Build();
+
+        Assert.True(File.Exists("ShouldNotDelete.txt"));
+    }
+
+    [Fact]
+    public void BuildWritesOutputFilesToOutputDirectory()
+    {
+        new MetalsharpProject(
+            clearOutputDirectory: true,
+            outputDirectory: "Output",
+            verbosity: LogLevel.None
+        )
+        .AddInput(new MetalsharpFile("text", "InputFile1.txt"))
+        .AddInput(new MetalsharpFile("text", "InputDir\\InputFile2.txt"))
+        .AddOutput(new MetalsharpFile("text", "OutputFile1.txt"))
+        .AddOutput(new MetalsharpFile("text", "OutputDir\\OutputFile2.txt"))
+        .Build();
+
+        Assert.True(File.Exists("Output\\OutputFile1.txt"));
+        Assert.True(File.Exists("Output\\OutputDir\\OutputFile2.txt"));
+
+        Assert.False(File.Exists("Output\\InputFile1.txt"));
+        Assert.False(File.Exists("Output\\InputDir\\InputFile2.txt"));
+    }
+
+    [Fact]
+    public void BuildInvokesBeforeBuildEvent()
+    {
+        var wasInvoked = false;
+
+        if (File.Exists("OutputFile3.txt"))
+        {
+            File.Delete("OutputFile3.txt");
+        }
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddOutput(new MetalsharpFile("text", "OutputFile3.txt"));
+
+        project.BeforeBuild += (sender, e) =>
+        {
+            wasInvoked = true;
+            Assert.False(File.Exists("OutputFile3.txt"));
+        };
+
+        project.Build();
+
+        Assert.True(wasInvoked);
+    }
+
+    [Fact]
+    public void BuildInvokesAfterBuildEvent()
+    {
+        var wasInvoked = false;
+
+        if (File.Exists("OutputFile4.txt"))
+        {
+            File.Delete("OutputFile4.txt");
+        }
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).AddOutput(new MetalsharpFile("text", "OutputFile4.txt"));
+
+        project.AfterBuild += (sender, e) =>
+        {
+            wasInvoked = true;
+            // File may or may not exist here - cannot test this?
+        };
+
+        project.Build();
+
+        Assert.True(wasInvoked);
+    }
+
+    #endregion
+
+    #region Metadata
+
+    [Fact]
+    public void MetadataSinglePairAddsAndOverwrites()
+    {
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
+
+        project.Meta("key", "value1");
+        Assert.True(project.Metadata.ContainsKey("key"));
+        Assert.True(project.Metadata["key"].ToString() == "value1");
+
+        project.Meta("key", "value2");
+        Assert.True(project.Metadata["key"].ToString() == "value2");
+    }
+
+    [Fact]
+    public void MetadataMultiplePairsAddAndOverwrite()
+    {
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
+
+        project.Meta(("key1", "value1"), ("key2", "value1"), ("key3", "value1"));
+        Assert.True(project.Metadata.ContainsKey("key1"));
+        Assert.True(project.Metadata.ContainsKey("key2"));
+        Assert.True(project.Metadata.ContainsKey("key3"));
+        Assert.True(project.Metadata["key1"].ToString() == "value1");
+        Assert.True(project.Metadata["key2"].ToString() == "value1");
+        Assert.True(project.Metadata["key3"].ToString() == "value1");
+
+        project.Meta(("key1", "value2"), ("key2", "value2"), ("key3", "value2"));
+        Assert.True(project.Metadata["key1"].ToString() == "value2");
+        Assert.True(project.Metadata["key2"].ToString() == "value2");
+        Assert.True(project.Metadata["key3"].ToString() == "value2");
+    }
+
+    #endregion
+
+    #region Move Files
+
+    [Fact]
+    public void MoveFilesByPathEquivalentToInputAndOutput()
+    {
+        var file = new MetalsharpFile("text", "dir1\\File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddInput(file)
+            .AddOutput(file)
+            .MoveFiles("dir1", "dir2");
+
+        Assert.True(project.InputFiles[0].Directory == "dir2");
+        Assert.True(project.OutputFiles[0].Directory == "dir2");
+    }
+
+    [Fact]
+    public void MoveFilesByPredicateEquivalentToInputAndOutput()
+    {
+        var file = new MetalsharpFile("text", "dir1\\File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddInput(file)
+            .AddOutput(file)
+            .MoveFiles(f => f.Text == "text", "dir2");
+
+        Assert.True(project.InputFiles[0].Directory == "dir2");
+        Assert.True(project.OutputFiles[0].Directory == "dir2");
+    }
+
+    [Fact]
+    public void MoveInputByPathMovesFilesCorrectly()
+    {
+        var file = new MetalsharpFile("text", "dir1\\File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddInput(file)
+            .MoveInput("dir1", "dir2");
+
+        Assert.True(project.InputFiles[0].Directory == "dir2");
+    }
+
+    [Fact]
+    public void MoveInputByPredicateSelectsFilesCorrectly()
+    {
+        var file = new MetalsharpFile("text", "dir1\\File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddInput(file)
+            .MoveInput(f => f.Text == "text", "dir2");
+
+        Assert.True(project.InputFiles[0].Directory == "dir2");
+    }
+
+    [Fact]
+    public void MoveOutputByPathMovesFilesCorrectly()
+    {
+        var file = new MetalsharpFile("text", "dir1\\File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddOutput(file)
+            .MoveOutput("dir1", "dir2");
+
+        Assert.True(project.OutputFiles[0].Directory == "dir2");
+    }
+
+    [Fact]
+    public void MoveOutputByPredicateSelectsFilesCorrectly()
+    {
+        var file = new MetalsharpFile("text", "dir1\\File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddOutput(file)
+            .MoveOutput(f => f.Text == "text", "dir2");
+
+        Assert.True(project.OutputFiles[0].Directory == "dir2");
+    }
+
+    #endregion
+
+    #region Remove Files
+
+    [Fact]
+    public void RemoveFilesByPathEquivalentToInputAndOutput()
+    {
+        var file = new MetalsharpFile("text", "File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddInput(file)
+            .AddOutput(file)
+            .RemoveFiles(file.FilePath);
+
+        Assert.DoesNotContain(file, project.InputFiles);
+        Assert.DoesNotContain(file, project.OutputFiles);
+    }
+
+    [Fact]
+    public void RemoveFilesByPredicateEquivalentToInputAndOutput()
+    {
+        var file = new MetalsharpFile("text", "File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddInput(file)
+            .AddOutput(file)
+            .RemoveFiles(f => f.Text == "text");
+
+        Assert.DoesNotContain(file, project.InputFiles);
+        Assert.DoesNotContain(file, project.OutputFiles);
+    }
+
+    [Fact]
+    public void RemoveInputByPathRemovesFilesCorrectly()
+    {
+        var file = new MetalsharpFile("text", "File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddInput(file)
+            .RemoveInput(file.FilePath);
+
+        Assert.DoesNotContain(file, project.InputFiles);
+    }
+
+    [Fact]
+    public void RemoveInputByPredicateSelectsFilesCorrectly()
+    {
+        var file = new MetalsharpFile("text", "File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddInput(file)
+            .RemoveInput(f => f.Text == "text");
+
+        Assert.DoesNotContain(file, project.InputFiles);
+    }
+
+    [Fact]
+    public void RemoveOutputByPathRemovesFilesCorrectly()
+    {
+        var file = new MetalsharpFile("text", "File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddOutput(file)
+            .RemoveOutput(file.FilePath);
+
+        Assert.DoesNotContain(file, project.OutputFiles);
+    }
+
+    [Fact]
+    public void RemoveOutputByPredicateSelectsFilesCorrectly()
+    {
+        var file = new MetalsharpFile("text", "File.txt");
+
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None })
+            .AddOutput(file)
+            .RemoveOutput(f => f.Text == "text");
+
+        Assert.DoesNotContain(file, project.OutputFiles);
+    }
+
+    #endregion
+
+    #region Use
+
+    [Fact]
+    public void UsePluginInstanceExecutesPlugin()
+    {
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).Use(new TestPlugin());
+
+        Assert.True((bool)project.Metadata["test"]);
+    }
+
+    [Fact]
+    public void UsePluginTypeExecutesPlugin()
+    {
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).Use<TestPlugin>();
+
+        Assert.True((bool)project.Metadata["test"]);
+    }
+
+    [Fact]
+    public void UseFuncExecutesFunc()
+    {
+        var wasExecuted = false;
+        new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None }).Use(proj => wasExecuted = true);
+
+        Assert.True(wasExecuted);
+    }
+
+    [Fact]
+    public void UseInvokesBeforeUseEevent()
+    {
+        var wasExecuted = false;
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
+
+        project.BeforeUse += (sender, e) =>
+        {
+            Assert.False(wasExecuted);
+        };
+
+        project.Use(proj => wasExecuted = true);
+    }
+
+    [Fact]
+    public void UseInvokesAfterUseEvent()
+    {
+        var wasExecuted = false;
+        var project = new MetalsharpProject(new MetalsharpOptions() { Verbosity = LogLevel.None });
+
+        project.AfterUse += (sender, e) =>
+        {
+            Assert.True(wasExecuted);
+        };
+
+        project.Use(proj => wasExecuted = true);
+    }
+
+    #endregion
 }

--- a/Metalsharp.Tests/TestPlugin.cs
+++ b/Metalsharp.Tests/TestPlugin.cs
@@ -1,8 +1,7 @@
-﻿namespace Metalsharp.Tests
+﻿namespace Metalsharp.Tests;
+
+public class TestPlugin : IMetalsharpPlugin
 {
-    public class TestPlugin : IMetalsharpPlugin
-    {
-        public void Execute(MetalsharpProject project) =>
-            project.Meta("test", true);
-    }
+    public void Execute(MetalsharpProject project) =>
+        project.Meta("test", true);
 }

--- a/Metalsharp/GlobalSuppressions.cs
+++ b/Metalsharp/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "Always off because annoying", Scope = "namespace", Target = "~N:Metalsharp")]

--- a/Metalsharp/Metalsharp.csproj
+++ b/Metalsharp/Metalsharp.csproj
@@ -1,17 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <RootNamespace>Metalsharp</RootNamespace>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
-    <Version>0.9.0-rc.1</Version>
+    <Version>0.9.1-rc.6</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Ian Wold</Authors>
     <Company />
-    <Copyright>Copyright (c) 2018 Ian Wold</Copyright>
+    <Copyright>Copyright (c) Ian Wold</Copyright>
     <PackageLicenseUrl>https://github.com/IanWold/Metalsharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/IanWold/Metalsharp/master/Icon.png</PackageIconUrl>
@@ -23,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Metalsharp.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net8\Metalsharp.xml</DocumentationFile>
     <DocumentationMarkdown>..\Metalsharp.Documentation\README.md</DocumentationMarkdown>
   </PropertyGroup>
 

--- a/Metalsharp/MetalsharpFile.cs
+++ b/Metalsharp/MetalsharpFile.cs
@@ -21,8 +21,24 @@ namespace Metalsharp;
 ///         new MetalsharpFile("# File Header!", "Directory\\File.md", new Dictionary&lt;string, object&gt; { ["draft"] = true });
 ///     ```
 /// </example>
-public class MetalsharpFile
+/// <remarks>
+///     Instantiate a new MetalsharpFile with the specified metadata.
+/// </remarks>
+/// 
+/// <param name="bytes">
+///     The contents of the file.
+/// </param>
+/// <param name="filePath">
+///     The virtual path of the file.
+/// </param>
+/// <param name="metadata">
+///     The metadata of the file, stored as a string, object dictionary.
+/// </param>
+public class MetalsharpFile(byte[] bytes, string filePath, Dictionary<string, object> metadata)
 {
+	private byte[] _bytes = bytes;
+	private string? _text;
+
 	/// <summary>
 	///     Instantiates a new MetalsharpFile with no metadata.
 	/// </summary>
@@ -33,19 +49,19 @@ public class MetalsharpFile
 	/// <param name="filePath">
 	///     The virtual path of the file.
 	/// </param>
-	public MetalsharpFile(string text, string filePath) : this(text, filePath, new Dictionary<string, object>()) { }
+	public MetalsharpFile(string text, string filePath) : this(text, filePath, []) { }
 
 	/// <summary>
 	///     Instantiates a new MetalsharpFile with no metadata.
 	/// </summary>
 	/// 
-	/// <param name="contents">
+	/// <param name="bytes">
 	///     The contents of the file.
 	/// </param>
 	/// <param name="filePath">
 	///     The virtual path of the file.
 	/// </param>
-	public MetalsharpFile(byte[] contents, string filePath) : this(contents, filePath, new Dictionary<string, object>()) { }
+	public MetalsharpFile(byte[] bytes, string filePath) : this(bytes, filePath, []) { }
 
 	/// <summary>
 	///     Instantiate a new MetalsharpFile with the specified metadata.
@@ -60,41 +76,30 @@ public class MetalsharpFile
 	/// <param name="metadata">
 	///     The metadata of the file, stored as a string, object dictionary.
 	/// </param>
-	public MetalsharpFile(string text, string filePath, Dictionary<string, object> metadata) : this(Encoding.Default.GetBytes(text), filePath, metadata) { }
+	public MetalsharpFile(string text, string filePath, Dictionary<string, object> metadata) : this(Encoding.Default.GetBytes(text), filePath, metadata) =>
+		_text = text;
 
-	/// <summary>
-	///     Instantiate a new MetalsharpFile with the specified metadata.
-	/// </summary>
-	/// 
-	/// <param name="contents">
-	///     The contents of the file.
-	/// </param>
-	/// <param name="filePath">
-	///     The virtual path of the file.
-	/// </param>
-	/// <param name="metadata">
-	///     The metadata of the file, stored as a string, object dictionary.
-	/// </param>
-	public MetalsharpFile(byte[] contents, string filePath, Dictionary<string, object> metadata)
+    #region Properties
+
+    /// <summary>
+    ///     The contents of the file.
+    /// </summary>
+    public byte[] Bytes
 	{
-		Contents = contents;
-		Metadata = metadata;
-		FilePath = filePath;
+		get => _bytes;
+		set
+		{
+			_bytes = value;
+			_text = null;
+		}
 	}
 
-	#region Properties
-
-	/// <summary>
-	///     The contents of the file.
-	/// </summary>
-	public byte[] Contents { get; set; }
-
-	/// <summary>
-	///     The virtual directory the file sits in.
-	/// </summary>
-	public string Directory
+    /// <summary>
+    ///     The virtual directory the file sits in.
+    /// </summary>
+    public string Directory
 	{
-		get => Path.GetDirectoryName(FilePath);
+		get => Path.GetDirectoryName(FilePath) ?? "./";
 		set => FilePath = Path.Combine(value, Name + Extension);
 	}
 
@@ -107,20 +112,20 @@ public class MetalsharpFile
 		set => FilePath = Path.Combine(Directory, Name + value);
 	}
 
-	/// <summary>
-	///     The full path of the file.
-	/// </summary>
-	public string FilePath { get; set; }
+    /// <summary>
+    ///     The full path of the file.
+    /// </summary>
+    public string FilePath { get; set; } = filePath;
 
-	/// <summary>
-	///     Metadata from the file.
-	/// </summary>
-	public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
+    /// <summary>
+    ///     Metadata from the file.
+    /// </summary>
+    public Dictionary<string, object> Metadata { get; set; } = metadata;
 
-	/// <summary>
-	///     The name of the file, without the extension.
-	/// </summary>
-	public string Name
+    /// <summary>
+    ///     The name of the file, without the extension.
+    /// </summary>
+    public string Name
 	{
 		get => Path.GetFileNameWithoutExtension(FilePath);
 		set => FilePath = Path.Combine(Directory, value + Extension);
@@ -129,7 +134,15 @@ public class MetalsharpFile
 	/// <summary>
 	///     The contents of the file as a string.
 	/// </summary>
-	public string Text => Encoding.Default.GetString(Contents);
+	public string Text
+	{
+		get => _text ??= Encoding.Default.GetString(Bytes);
+		set
+		{
+			_bytes = Encoding.Default.GetBytes(value);
+			_text = value;
+		}
+	}
 
 	#endregion
 

--- a/Metalsharp/MetalsharpFileCollection.cs
+++ b/Metalsharp/MetalsharpFileCollection.cs
@@ -8,16 +8,12 @@ namespace Metalsharp;
 /// <summary>
 ///     Represents a collection of Metalsharp files.
 /// </summary>
-/// 
-/// <typeparam name="T">
-///     The type of the files. These must be of type `IMetalsharpFile`.
-/// </typeparam>
 public class MetalsharpFileCollection : IList<MetalsharpFile>
 {
 	/// <summary>
 	///     The Metalsharp files in the collection.
 	/// </summary>
-	readonly List<MetalsharpFile> _items = new();
+	readonly List<MetalsharpFile> _items = [];
 
 	/// <summary>
 	///     Instantiate an empty collection.
@@ -75,7 +71,7 @@ public class MetalsharpFileCollection : IList<MetalsharpFile>
 	}
 
 	public int Count =>
-		Items.Count();
+        Items.Count;
 
 	public bool IsReadOnly =>
 		false;
@@ -128,9 +124,6 @@ public static class IEnumerableExtensions
 	///     Mimic `IEnumerable.ToList`, allowing the easy conversion of an enumerable of files to an `IMetalsharpFileCollection`
 	/// </summary>
 	/// 
-	/// <typeparam name="T">
-	///     The type of the collection. Must derive from `IMetalsharpFile`.
-	/// </typeparam>
 	/// <param name="list">
 	///     The `IEnumerable` of `IMetalsharpFile`s to convert to an IMetalsharpFileCollection.
 	/// </param>

--- a/Metalsharp/MetalsharpOptions.cs
+++ b/Metalsharp/MetalsharpOptions.cs
@@ -6,7 +6,14 @@ namespace Metalsharp;
 /// <summary>
 ///		Represents the configuration options for a Metalsharp project.
 /// </summary>
-public class MetalsharpOptions
+/// <remarks>
+///		Instantiate the default configuration.
+/// </remarks>
+public class MetalsharpOptions(
+    bool clearOutputDirectory = MetalsharpOptions.DefaultClearOutputDirectory,
+    string outputDirectory = MetalsharpOptions.DefaultOutputDirectory,
+    LogLevel verbosity = MetalsharpOptions.DefaultVerbosity
+)
 {
 	/// <summary>
 	/// The default value for `ClearOutputDirectory`
@@ -23,30 +30,16 @@ public class MetalsharpOptions
 	/// </summary>
 	public const LogLevel DefaultVerbosity = LogLevel.Error;
 
-	/// <summary>
-	///		Instantiate the default configuration.
-	/// </summary>
-	public MetalsharpOptions(
-		bool clearOutputDirectory = DefaultClearOutputDirectory,
-		string outputDirectory = DefaultOutputDirectory,
-		LogLevel verbosity = DefaultVerbosity
-	)
+    /// <summary>
+    ///		Instantiate configuration from command line arguments.
+    /// </summary>
+    /// 
+    /// <param name="args">
+    ///		The command line arguments
+    /// </param>
+    public static MetalsharpOptions FromArgs(string[] args)
 	{
-		ClearOutputDirectory = clearOutputDirectory;
-		OutputDirectory = outputDirectory;
-		Verbosity = verbosity;
-	}
-
-	/// <summary>
-	///		Instantiate configuration from command line arguments.
-	/// </summary>
-	/// 
-	/// <param name="args">
-	///		The command line arguments
-	/// </param>
-	public static MetalsharpOptions FromArgs(string[] args)
-	{
-		MetalsharpOptions configuration = null;
+		MetalsharpOptions configuration = new();
 
 		new Parser()
 			.ParseArguments<MetalsharpOptions>(args)
@@ -56,25 +49,25 @@ public class MetalsharpOptions
 		return configuration;
 	}
 
-	/// <summary>
-	///     Whether Metalsharp should remove all the files in the output directory before writing any to that directory.
-	///     
-	///     `false` by default.
-	/// </summary>
-	[Option('c', "clear", Default = DefaultClearOutputDirectory, HelpText = "Whether Metalsharp should remove all the files in the output directory before writing any to that directory.")]
-	public bool ClearOutputDirectory { get; init; }
+    /// <summary>
+    ///     Whether Metalsharp should remove all the files in the output directory before writing any to that directory.
+    ///     
+    ///     `false` by default.
+    /// </summary>
+    [Option('c', "clear", Default = DefaultClearOutputDirectory, HelpText = "Whether Metalsharp should remove all the files in the output directory before writing any to that directory.")]
+    public bool ClearOutputDirectory { get; init; } = clearOutputDirectory;
 
-	/// <summary>
-	///     The directory to which the files will be output.
-	///     
-	///     `.\` by default.
-	/// </summary>
-	[Option('o', "output", Default = DefaultOutputDirectory, HelpText = "The directory to which the files will be output.")]
-	public string OutputDirectory { get; init; }
+    /// <summary>
+    ///     The directory to which the files will be output.
+    ///     
+    ///     `.\` by default.
+    /// </summary>
+    [Option('o', "output", Default = DefaultOutputDirectory, HelpText = "The directory to which the files will be output.")]
+    public string OutputDirectory { get; init; } = outputDirectory;
 
-	/// <summary>
-	///		The minimum level to log.
-	/// </summary>
-	[Option('v', "verbosity", Default = DefaultVerbosity, HelpText = "The verbosity level for the log output.")]
-	public LogLevel Verbosity { get; init; }
+    /// <summary>
+    ///		The minimum level to log.
+    /// </summary>
+    [Option('v', "verbosity", Default = DefaultVerbosity, HelpText = "The verbosity level for the log output.")]
+    public LogLevel Verbosity { get; init; } = verbosity;
 }

--- a/Metalsharp/MetalsharpProject.cs
+++ b/Metalsharp/MetalsharpProject.cs
@@ -80,32 +80,32 @@ public class MetalsharpProject
 	/// <summary>
 	///     Invoked before `Use()`
 	/// </summary>
-	public event EventHandler BeforeUse;
+	public event EventHandler? BeforeUse;
 
 	/// <summary>
 	///     Invoked after `Use()`
 	/// </summary>
-	public event EventHandler AfterUse;
+	public event EventHandler? AfterUse;
 
 	/// <summary>
 	///     Invoked before `Build()`
 	/// </summary>
-	public event EventHandler BeforeBuild;
+	public event EventHandler? BeforeBuild;
 
 	/// <summary>
 	///     Invoked after `Build()`
 	/// </summary>
-	public event EventHandler AfterBuild;
+	public event EventHandler? AfterBuild;
 
 	/// <summary>
 	///		Invoked when any message is sent to the logger, irrespective of the specified log level.
 	/// </summary>
-	public EventHandler<LogEventArgs> OnAnyLog;
+	public EventHandler<LogEventArgs>? OnAnyLog;
 
 	/// <summary>
 	///		Invoked when a message is logged at or above the specified log level.
 	/// </summary>
-	public EventHandler<LogEventArgs> OnLog;
+	public EventHandler<LogEventArgs>? OnLog;
 
 	#endregion
 
@@ -119,17 +119,17 @@ public class MetalsharpProject
 	/// <summary>
 	///     The directory-level metadata.
 	/// </summary>
-	public Dictionary<string, object> Metadata { get; init; } = new Dictionary<string, object>();
+	public Dictionary<string, object> Metadata { get; init; } = [];
 
 	/// <summary>
 	///     The input files of the project.
 	/// </summary>
-	public MetalsharpFileCollection InputFiles { get; init; } = new();
+	public MetalsharpFileCollection InputFiles { get; init; } = [];
 
 	/// <summary>
 	///     The files to output during building.
 	/// </summary>
-	public MetalsharpFileCollection OutputFiles { get; init; } = new();
+	public MetalsharpFileCollection OutputFiles { get; init; } = [];
 
 	#endregion
 
@@ -402,14 +402,14 @@ public class MetalsharpProject
 			var path = Path.Combine(Options.OutputDirectory, file.FilePath);
 			var directoryPath = Path.GetDirectoryName(path);
 
-			if (!Directory.Exists(directoryPath))
+			if (directoryPath is not null && !Directory.Exists(directoryPath))
 			{
 				LogDebug($"Creating directory {directoryPath}");
 				Directory.CreateDirectory(directoryPath);
 			}
 
 			LogDebug($"Wrting file {path}");
-			File.WriteAllBytes(path, file.Contents);
+			File.WriteAllBytes(path, file.Bytes);
 		}
 
 		LogInfo("\nFinalizing Build");
@@ -614,7 +614,7 @@ public class MetalsharpProject
 	{
 		foreach (var (key, value) in pairs)
 		{
-			if (Metadata.ContainsKey(key))
+			if (!Metadata.TryAdd(key, value))
 			{
 				LogDebug($"Updating metadata [{key}] = {value}");
 				Metadata[key] = value;
@@ -622,7 +622,6 @@ public class MetalsharpProject
 			else
 			{
 				LogDebug($"Adding metadata [{key}] = {value}");
-				Metadata.Add(key, value);
 			}
 		}
 
@@ -855,7 +854,7 @@ public class MetalsharpProject
 	/// <returns>
 	///     The current `MetalsharpProject`, allowing it to be fluent.
 	/// </returns>
-	public MetalsharpProject MoveInput(Predicate<MetalsharpFile> predicate, string toDirectory, string logMessage = null)
+	public MetalsharpProject MoveInput(Predicate<MetalsharpFile> predicate, string toDirectory, string? logMessage = null)
 	{
 		LogInfo($"Removing files in Input to {toDirectory} from{(logMessage is not null ? $": {logMessage}" : "")}");
 
@@ -975,7 +974,7 @@ public class MetalsharpProject
 	/// <returns>
 	///     The current `MetalsharpProject`, allowing it to be fluent.
 	/// </returns>
-	public MetalsharpProject MoveOutput(Predicate<MetalsharpFile> predicate, string toDirectory, string logMessage = null)
+	public MetalsharpProject MoveOutput(Predicate<MetalsharpFile> predicate, string toDirectory, string? logMessage = null)
 	{
 		LogInfo($"Removing files in Output to {toDirectory} from{(logMessage is not null ? $": {logMessage}" : "")}");
 
@@ -1147,7 +1146,7 @@ public class MetalsharpProject
 	/// <returns>
 	///     The current `MetalsharpProject`, allowing it to be fluent.
 	/// </returns>
-	public MetalsharpProject RemoveInput(Predicate<MetalsharpFile> predicate, string logMessage = null)
+	public MetalsharpProject RemoveInput(Predicate<MetalsharpFile> predicate, string? logMessage = null)
 	{
 		LogInfo($"Removing files from Input{(logMessage is not null ? $": {logMessage}" : "")}");
 
@@ -1240,7 +1239,7 @@ public class MetalsharpProject
 	/// <returns>
 	///     The current `MetalsharpProject`, allowing it to be fluent.
 	/// </returns>
-	public MetalsharpProject RemoveOutput(Predicate<MetalsharpFile> predicate, string logMessage = null)
+	public MetalsharpProject RemoveOutput(Predicate<MetalsharpFile> predicate, string? logMessage = null)
 	{
 		LogInfo($"Removing files from Output{(logMessage is not null ? $": {logMessage}" : "")}");
 
@@ -1301,7 +1300,7 @@ public class MetalsharpProject
 	/// <returns>
 	///     The current `MetalsharpProject`, allowing it to be fluent.
 	/// </returns>
-	public MetalsharpProject Use(Action<MetalsharpProject> func, string functionName = null) =>
+	public MetalsharpProject Use(Action<MetalsharpProject> func, string? functionName = null) =>
 		Use(func, "function", functionName ?? "<anonymous>");
 
 	/// <summary>
@@ -1323,7 +1322,7 @@ public class MetalsharpProject
 	///     The current `MetalsharpProject`, allowing it to be fluent.
 	/// </returns>
 	public MetalsharpProject Use(IMetalsharpPlugin plugin) =>
-		Use(i => plugin.Execute(i), "plugin", plugin.GetType().Name);
+		Use(plugin.Execute, "plugin", plugin.GetType().Name);
 
 	/// <summary>
 	///     Invoke a plugin by type. The plugin must have a default (no arguments) constructor.

--- a/Metalsharp/Plugins/Collections/Collections.cs
+++ b/Metalsharp/Plugins/Collections/Collections.cs
@@ -49,12 +49,18 @@ namespace Metalsharp;
 ///         project.GetOutputFilesFromCollection("posts").ToList().ForEach(post => post.Metadata.Add("author", "Mickey Mouse"));
 ///     ```
 /// </example>
-public class Collections : IMetalsharpPlugin
+/// <remarks>
+///     Instantiates the plugin with the definitions of the collections.
+/// </remarks>
+/// <param name="definitions">
+///     The definitions of the collections, including the name of the collection and the predicate which matches its files.
+/// </param>
+public class Collections(params (string name, Predicate<MetalsharpFile> predicate)[] definitions) : IMetalsharpPlugin
 {
 	/// <summary>
 	///     Contains the definitions of the collections.
 	/// </summary>
-	private readonly (string name, Predicate<MetalsharpFile> predicate)[] _definitions;
+	private readonly (string name, Predicate<MetalsharpFile> predicate)[] _definitions = definitions;
 
 	/// <summary>
 	///     Instantiate the plugin with a single collection definition.
@@ -68,23 +74,14 @@ public class Collections : IMetalsharpPlugin
 	/// </param>
 	public Collections(string name, Predicate<MetalsharpFile> predicate) : this((name, predicate)) { }
 
-	/// <summary>
-	///     Instantiates the plugin with the definitions of the collections.
-	/// </summary>
-	/// <param name="definitions">
-	///     The definitions of the collections, including the name of the collection and the predicate which matches its files.
-	/// </param>
-	public Collections(params (string name, Predicate<MetalsharpFile> predicate)[] definitions) =>
-		_definitions = definitions;
-
-	/// <summary>
-	///     Invokes the plugin.
-	/// </summary>
-	/// 
-	/// <param name="project">
-	///     The `MetalsharpProject` on which the plugin will be invoked.
-	/// </param>
-	public void Execute(MetalsharpProject project)
+    /// <summary>
+    ///     Invokes the plugin.
+    /// </summary>
+    /// 
+    /// <param name="project">
+    ///     The `MetalsharpProject` on which the plugin will be invoked.
+    /// </param>
+    public void Execute(MetalsharpProject project)
 	{
 		var collections = new Dictionary<string, Dictionary<string, string[]>>();
 

--- a/Metalsharp/Plugins/Collections/CollectionsPluginExtensions.cs
+++ b/Metalsharp/Plugins/Collections/CollectionsPluginExtensions.cs
@@ -151,7 +151,7 @@ public static class CollectionsPluginExtensions
 		&& collectionsDictionary[name] is Dictionary<string, string[]> collection
 		&& collection["input"] is string[] inputsCollection
 			? inputsCollection
-			: Array.Empty<string>();
+			: [];
 
 	/// <summary>
 	///     Given the name of a collection, returns the input files in that collection from the metadata of the `MetalsharpProject`.
@@ -179,7 +179,7 @@ public static class CollectionsPluginExtensions
 	public static IEnumerable<MetalsharpFile> GetInputFilesFromCollection(this MetalsharpProject project, string name) =>
 		project.GetInputCollection(name) is string[] files && files.Length > 0
 			? project.InputFiles.Where(file => files.Contains(file.FilePath))
-			: Enumerable.Empty<MetalsharpFile>();
+			: [];
 
 	/// <summary>
 	///     Given the name of a collection, returns the output file paths in that collection from the metadata of the `MetalsharpProject`.
@@ -209,7 +209,7 @@ public static class CollectionsPluginExtensions
 		&& collectionsDictionary[name] is Dictionary<string, string[]> collection
 		&& collection["output"] is string[] outputsCollection
 			? outputsCollection
-			: Array.Empty<string>();
+			: [];
 
 	/// <summary>
 	///     Given the name of a collection, returns the output files in that collection from the metadata of the `MetalsharpProject`.
@@ -237,5 +237,5 @@ public static class CollectionsPluginExtensions
 	public static IEnumerable<MetalsharpFile> GetOutputFilesFromCollection(this MetalsharpProject project, string name) =>
 		project.GetOutputCollection(name) is string[] files && files.Length > 0
 			? project.OutputFiles.Where(file => files.Contains(file.FilePath))
-			: Enumerable.Empty<MetalsharpFile>();
+			: [];
 }

--- a/Metalsharp/Plugins/Debug/Debug.cs
+++ b/Metalsharp/Plugins/Debug/Debug.cs
@@ -19,12 +19,19 @@ namespace Metalsharp;
 ///         .Use ... ;
 ///     ```
 /// </example>
-public class Debug : IMetalsharpPlugin
+/// <remarks>
+///     Instantiate `Debug` with a custom action to perform each time a log is written. This can be used to output to different sources or execute different debug actions.
+/// </remarks>
+/// 
+/// <param name="onLog">
+///     The action to execute when writing a log.
+/// </param>
+public class Debug(Action<string> onLog) : IMetalsharpPlugin
 {
 	/// <summary>
 	///     The action to execute when writing a log.
 	/// </summary>
-	private readonly Action<string> _onLog;
+	private readonly Action<string> _onLog = onLog;
 
 	/// <summary>
 	///     A count of the number of calls to .Use() against the directory.
@@ -73,24 +80,14 @@ public class Debug : IMetalsharpPlugin
 	})
 	{ }
 
-	/// <summary>
-	///     Instantiate `Debug` with a custom action to perform each time a log is written. This can be used to output to different sources or execute different debug actions.
-	/// </summary>
-	/// 
-	/// <param name="onLog">
-	///     The action to execute when writing a log.
-	/// </param>
-	public Debug(Action<string> onLog) =>
-		_onLog = onLog;
-
-	/// <summary>
-	///     Invokes the plugin.
-	/// </summary>
-	/// 
-	/// <param name="project">
-	///     The `MetalsharpProject` to output debug logs for.
-	/// </param>
-	public void Execute(MetalsharpProject project)
+    /// <summary>
+    ///     Invokes the plugin.
+    /// </summary>
+    /// 
+    /// <param name="project">
+    ///     The `MetalsharpProject` to output debug logs for.
+    /// </param>
+    public void Execute(MetalsharpProject project)
 	{
 		project.AfterUse += (sender, e) =>
 			_onLog(

--- a/Metalsharp/Plugins/Frontmatter/Frontmatter.cs
+++ b/Metalsharp/Plugins/Frontmatter/Frontmatter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -46,11 +47,11 @@ public class Frontmatter : IMetalsharpPlugin
 		foreach (var file in project.InputFiles)
 		{
 			project.LogDebug($"Looking for frontmatter in {file.FilePath}");
-			if (TryGetFrontmatter(file.Text, out Dictionary<string, object> metadata, out string text))
+			if (TryGetFrontmatter(file.Text, out var metadata, out var text))
 			{
 				project.LogDebug($"    Found frontmatter:");
 
-				file.Contents = Encoding.Default.GetBytes(text);
+				file.Bytes = Encoding.Default.GetBytes(text);
 
 				foreach (var pair in metadata)
 				{
@@ -86,15 +87,15 @@ public class Frontmatter : IMetalsharpPlugin
 	/// <returns>
 	///     `true` if frontmatter text was found and parsed; `false` otherwise.
 	/// </returns>
-	private static bool TryGetFrontmatter(string document, out Dictionary<string, object> frontmatter, out string remainder)
+	private static bool TryGetFrontmatter(string document, [NotNullWhen(true)] out Dictionary<string, object>? frontmatter, [NotNullWhen(true)] out string? remainder)
 	{
-		if (document.StartsWith("---") && TryGetYamlFrontmatter(document, out Dictionary<string, object> yamlFrontmatter, out string yamlRemainder))
+		if (document.StartsWith("---") && TryGetYamlFrontmatter(document, out var yamlFrontmatter, out var yamlRemainder))
 		{
 			frontmatter = yamlFrontmatter;
 			remainder = yamlRemainder;
 			return true;
 		}
-		else if (document.StartsWith(";;;") && TryGetJsonFrontmatter(document, out Dictionary<string, object> jsonFrontmatter, out string jsonRemainder))
+		else if (document.StartsWith(";;;") && TryGetJsonFrontmatter(document, out var jsonFrontmatter, out var jsonRemainder))
 		{
 			frontmatter = jsonFrontmatter;
 			remainder = jsonRemainder;
@@ -125,9 +126,9 @@ public class Frontmatter : IMetalsharpPlugin
 	/// <returns>
 	///     `true` if frontmatter text was found and parsed; `false` otherwise.
 	/// </returns>
-	private static bool TryGetYamlFrontmatter(string document, out Dictionary<string, object> frontmatter, out string remainder)
+	private static bool TryGetYamlFrontmatter(string document, [NotNullWhen(true)] out Dictionary<string, object>? frontmatter, [NotNullWhen(true)] out string? remainder)
 	{
-		var split = document.Split(new[] { "---" }, StringSplitOptions.None);
+		var split = document.Split(["---"], StringSplitOptions.None);
 
 		frontmatter = null;
 		remainder = null;
@@ -172,9 +173,9 @@ public class Frontmatter : IMetalsharpPlugin
 	/// <returns>
 	///     `true` if frontmatter text was found and parsed; `false` otherwise.
 	/// </returns>
-	private static bool TryGetJsonFrontmatter(string document, out Dictionary<string, object> frontmatter, out string remainder)
+	private static bool TryGetJsonFrontmatter(string document, [NotNullWhen(true)] out Dictionary<string, object>? frontmatter, [NotNullWhen(true)] out string? remainder)
 	{
-		var split = document.Split(new[] { ";;;" }, StringSplitOptions.None);
+		var split = document.Split([";;;"], StringSplitOptions.None);
 
 		frontmatter = null;
 		remainder = null;


### PR DESCRIPTION
Updates to .NET 8. Includes:

* Projects use .NET 8
* Code style/formatting updates for new vresions of framework and language
* Enable `Nullable` and declare types nullable where necessary
* Add utility to set `MetalsharpFile` contents by Text or Bytes

Yet to do:

* Update Nuget references to latest versions
* Would be nice to update solution to use tabs consistently